### PR TITLE
Windows build problems (VC9 from Windows 7 SDK)

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -3,18 +3,22 @@
 // $Revision$
 // vim:ft=javascript
 
+// edited to link to static build of spidermonkey,
+// and assumes lib and headers are copied to the 'deps' area of the PHP environment.
+
 ARG_WITH("spidermonkey", "spidermonkey support", "no");
 
 if (PHP_SPIDERMONKEY != "no") {
     if (CHECK_LIB("js32.lib", "spidermonkey", PHP_SPIDERMONKEY) &&
-        CHECK_HEADER_ADD_INCLUDE("jsapi.h", "CFLAGS_SPIDERMONKEY", PHP_SPIDERMONKEY + "\\include\\js")) {
+    		CHECK_LIB("winmm.lib", "spidermonkey") &&
+        CHECK_HEADER_ADD_INCLUDE("jsapi.h", "CFLAGS_SPIDERMONKEY", PHP_SPIDERMONKEY + ";" + PHP_PHP_BUILD + "\\include\\js")) {
 
         EXTENSION("spidermonkey", "spidermonkey.c spidermonkey_context.c spidermonkey_external.c spidermonkey_streams.c");
 
         AC_DEFINE("HAVE_SPIDERMONKEY", 1, "Have SpiderMonkey library");
-        ADD_FLAG("CFLAGS_SPIDERMONKEY", "/D XP_WIN /D WIN32");
+        ADD_FLAG("CFLAGS_SPIDERMONKEY", "/D XP_WIN /D WIN32 /D STATIC_JS_API");
 
-    } else {
+	} else {
         WARNING("spidermonkey not enabled; libraries and headers not found");
     }
 

--- a/php_spidermonkey.h
+++ b/php_spidermonkey.h
@@ -26,7 +26,7 @@
 /* Define Extension Properties */
 #define PHP_SPIDERMONKEY_EXTNAME	"spidermonkey"
 #define PHP_SPIDERMONKEY_MINFO_NAME "SpiderMonkey"
-#define PHP_SPIDERMONKEY_EXTVER		"@PACKAGE_VERSION@"
+#define PHP_SPIDERMONKEY_EXTVER		"1.0.0"
 
 /* Import configure options
    when building outside of
@@ -37,6 +37,7 @@
 
 /* Include PHP Standard Header */
 #include "php.h"
+#include "zend_exceptions.h"
 #define XP_UNIX
 /* Include JSAPI Header */
 #include "jsapi.h"

--- a/spidermonkey.c
+++ b/spidermonkey.c
@@ -20,10 +20,19 @@
 */
 
 #include "php_spidermonkey.h"
+#include "standard/info.h"
 
 static int le_jscontext_descriptor;
 
+#ifdef __CPP
+extern "C" {
+#endif
+
 ZEND_DECLARE_MODULE_GLOBALS(spidermonkey);
+
+#ifdef __CPP
+}
+#endif
 
 zend_module_entry spidermonkey_module_entry = {
 	STANDARD_MODULE_HEADER,
@@ -70,7 +79,7 @@ static void php_jscontext_object_free_storage(void *object TSRMLS_DC)
 	 * destroy it
 	 */
 	if (intern->ct != (JSContext*)NULL)
-		JS_DestroyContext(intern->ct);
+		JS_DestroyContext((JSContext *)intern->ct);
 
 	if (intern->ec_ht != NULL)
 	{
@@ -481,7 +490,6 @@ void zval_to_jsval(zval *val, JSContext *ctx, jsval *jval TSRMLS_DC)
 			jsref->ht = NULL;
 			jsref->obj = val;
 			/* auto define functions for stream */
-			php_stream *stream;
 			php_stream_from_zval_no_verify(stream, &val);
 
 			if (stream != NULL) {

--- a/spidermonkey_context.c
+++ b/spidermonkey_context.c
@@ -254,7 +254,7 @@ PHP_METHOD(JSContext, setVersion)
 	}
 
 	intern = (php_jscontext_object *) zend_object_store_get_object(getThis() TSRMLS_CC);
-	old_version = JS_SetVersion(intern->ct, version);
+	old_version = JS_SetVersion(intern->ct, (JSVersion)version);
 	
 	if (JS_GetVersion(intern->ct) == version)
 	{
@@ -292,7 +292,7 @@ PHP_METHOD(JSContext, getVersionString)
 		RETURN_NULL();
 	}
 
-	version_str = JS_VersionToString(version);
+	version_str = JS_VersionToString((JSVersion)version);
 	l = strlen(version_str);
 
 	RETVAL_STRINGL(estrndup(version_str, l), l, 0);

--- a/spidermonkey_external.c
+++ b/spidermonkey_external.c
@@ -26,7 +26,10 @@
 /* TODO: change that to an exception */
 void reportError(JSContext *cx, const char *message, JSErrorReport *report)
 {
-	TSRMLS_FETCH();
+	#ifdef ZTS
+	TSRMLS_FETCH();			/* MSVC9 : NULL statement, C compiler won't allow variable definitions below this line.
+								Cannot compile as C++ because conflict with the name 'class' */
+	#endif
 	/* throw error */
 	zend_throw_exception(zend_exception_get_default(TSRMLS_C), (char *) message, 0 TSRMLS_CC);
 }
@@ -54,7 +57,10 @@ JSBool generic_call(JSContext *cx, JSObject *obj, uintN argc, jsval *argv, jsval
 JSBool generic_call(JSContext *cx, uintN argc, jsval *vp)
 #endif
 {
-	TSRMLS_FETCH();
+#ifdef ZTS
+	TSRMLS_FETCH(); /* MSVC9 : NULL statement, C compiler won't allow variable definitions below this line.
+								Cannot compile as C++ because conflict with the name 'class' */
+#endif
 	JSFunction				*func;
 	JSString				*jfunc_name;
 	JSClass					*class;
@@ -149,7 +155,10 @@ JSBool generic_constructor(JSContext *cx, JSObject *obj, uintN argc, jsval *argv
 JSBool generic_constructor(JSContext *cx, uintN argc, jsval *vp)
 #endif
 {
-	TSRMLS_FETCH();
+#ifdef ZTS
+	TSRMLS_FETCH();			/* MSVC9 : NULL statement, C compiler won't allow variable definitions below this line.
+								Cannot compile as C++ because conflict with the name 'class' */
+#endif
 	JSFunction				*class;
 	JSString				*jclass_name;
 	char					*class_name;
@@ -307,7 +316,10 @@ JSBool JS_PropertySetterPHP(JSContext *cx, JSObject *obj, jsval id, jsval *vp)
 JSBool JS_PropertySetterPHP(JSContext *cx, JSObject *obj, jsid id, JSBool strict, jsval *vp)
 #endif
 {
-	TSRMLS_FETCH();
+	#ifdef ZTS
+	TSRMLS_FETCH();			/* MSVC9 : NULL statement, C compiler won't allow variable definitions below this line.
+								Cannot compile as C++ because conflict with the name 'class' */
+	#endif
 	php_jsobject_ref		*jsref;
 	php_jscontext_object	*intern;
 	JSClass					*class;
@@ -362,7 +374,10 @@ JSBool JS_PropertyGetterPHP(JSContext *cx, JSObject *obj, jsval id, jsval *vp)
 JSBool JS_PropertyGetterPHP(JSContext *cx, JSObject *obj, jsid id, jsval *vp)
 #endif
 {
-	TSRMLS_FETCH();
+	#ifdef ZTS
+	TSRMLS_FETCH();			/* MSVC9 : NULL statement, C compiler won't allow variable definitions below this line.
+								Cannot compile as C++ because conflict with the name 'class' */
+	#endif
 	php_jsobject_ref		*jsref;
 	php_jscontext_object	*intern;
 	JSClass					*class;

--- a/spidermonkey_streams.c
+++ b/spidermonkey_streams.c
@@ -29,7 +29,10 @@ JSBool js_stream_read(JSContext *cx, JSObject *obj, uintN argc, jsval *argv, jsv
 JSBool js_stream_read(JSContext *cx, uintN argc, jsval *vp)
 #endif
 {
-	TSRMLS_FETCH();
+	#ifdef ZTS
+	TSRMLS_FETCH();			/* MSVC9 : NULL statement, C compiler won't allow variable definitions below this line.
+								Cannot compile as C++ because conflict with the name 'class' */
+	#endif
 	php_jscontext_object	*intern;
 	php_jsobject_ref		*jsref;
 	php_stream				*stream = NULL;
@@ -99,7 +102,10 @@ JSBool js_stream_getline(JSContext *cx, JSObject *obj, uintN argc, jsval *argv, 
 JSBool js_stream_getline(JSContext *cx, uintN argc, jsval *vp)
 #endif
 {
-	TSRMLS_FETCH();
+	#ifdef ZTS
+	TSRMLS_FETCH();			/* MSVC9 : NULL statement, C compiler won't allow variable definitions below this line.
+								Cannot compile as C++ because conflict with the name 'class' */
+	#endif
 	php_jscontext_object	*intern;
 	php_jsobject_ref		*jsref;
 	php_stream				*stream = NULL;
@@ -170,7 +176,10 @@ JSBool js_stream_seek(JSContext *cx, JSObject *obj, uintN argc, jsval *argv, jsv
 JSBool js_stream_seek(JSContext *cx, uintN argc, jsval *vp)
 #endif
 {
-	TSRMLS_FETCH();
+	#ifdef ZTS
+	TSRMLS_FETCH();			/* MSVC9 : NULL statement, C compiler won't allow variable definitions below this line.
+								Cannot compile as C++ because conflict with the name 'class' */
+	#endif
 	php_jscontext_object	*intern;
 	php_jsobject_ref		*jsref;
 	php_stream				*stream = NULL;
@@ -228,7 +237,10 @@ JSBool js_stream_write(JSContext *cx, JSObject *obj, uintN argc, jsval *argv, js
 JSBool js_stream_write(JSContext *cx, uintN argc, jsval *vp)
 #endif
 {
-	TSRMLS_FETCH();
+	#ifdef ZTS
+	TSRMLS_FETCH();			/* MSVC9 : NULL statement, C compiler won't allow variable definitions below this line.
+								Cannot compile as C++ because conflict with the name 'class' */
+	#endif
 	php_jscontext_object	*intern;
 	php_jsobject_ref		*jsref;
 	php_stream				*stream = NULL;
@@ -300,7 +312,10 @@ JSBool js_stream_tell(JSContext *cx, JSObject *obj, uintN argc, jsval *argv, jsv
 JSBool js_stream_tell(JSContext *cx, uintN argc, jsval *vp)
 #endif
 {
-	TSRMLS_FETCH();
+	#ifdef ZTS
+	TSRMLS_FETCH();			/* MSVC9 : NULL statement, C compiler won't allow variable definitions below this line.
+								Cannot compile as C++ because conflict with the name 'class' */
+	#endif
 	php_jscontext_object	*intern;
 	php_jsobject_ref		*jsref;
 	php_stream				*stream = NULL;


### PR DESCRIPTION
Hi

Thanks for your great library.  It's one of the most exciting things I've used this year, and solved a problem where I had to parse a browser PAC file inside PHP.  The possibilities are huge with this extension, it works very well, and is easy to use.

I have posted the changes I had to make to get it to build on VC9, you might have better ways of doing it than me, but the latest MS compiler is stricter than before.

I built with the static spidermonkey from Mozilla, so the extension is on the large side (1.5M), but doesn't need another DLL.

Rob
