### PR TITLE
fixed check for osx, which uses dylib extension

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -36,7 +36,7 @@ if test "$PHP_SPIDERMONKEY" != "no"; then
     done
     # test for the libname independantely
     for j in js mozjs mozjs185; do
-      test -f $i/lib/lib$j.so && SPIDERMONKEY_LIBNAME=$j && break
+      (test -f $i/lib/lib$j.so || test -f $i/lib/lib$j.dylib) && SPIDERMONKEY_LIBNAME=$j && break
     done
     test -f $i/include/$j/jsapi.h && break
   done


### PR DESCRIPTION
This patch fixes the problem with issue #3, where building this extension on osx fails. Tested with spidermonkey 1.7.0.
